### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/App/server.py
+++ b/App/server.py
@@ -1,7 +1,9 @@
 from flask import Flask, jsonify
 from web3 import Web3
 import pyopenxr as openxr
+import logging
 
+logging.basicConfig(level=logging.ERROR, format='%(asctime)s %(levelname)s %(message)s')
 # Blockchain Setup (Ethereum Example)
 infura_url = "https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID"
 web3 = Web3(Web3.HTTPProvider(infura_url))
@@ -32,7 +34,8 @@ def get_location_data(location_id):
             "owner": location_metadata[2]
         })
     except Exception as e:
-        return jsonify({"error": str(e)})
+        logging.error("Error fetching location data", exc_info=True)
+        return jsonify({"error": "An internal error has occurred."})
 
 # VR Integration (Simple OpenXR Initialization)
 def initialize_vr_world():


### PR DESCRIPTION
Potential fix for [https://github.com/ewdlop/BlockChainDevelopmentNote/security/code-scanning/1](https://github.com/ewdlop/BlockChainDevelopmentNote/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error message on the server side and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the response.

1. Import the logging module.
2. Configure the logging settings.
3. Log the exception details in the except block.
4. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
