### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/App/scripts/interact.js
+++ b/App/scripts/interact.js
@@ -24,7 +24,14 @@ const web3 = new Web3('http://localhost:8545');
 
 const account = process.env.ACCOUNT_ADDRESS;
 
-logger.info(`Account address: ${account}`); // Log the account address
+function maskAccountAddress(address) {
+  if (address && address.length > 10) {
+    return address.substring(0, 6) + '...' + address.substring(address.length - 4);
+  }
+  return address;
+}
+
+logger.info(`Account address: ${maskAccountAddress(account)}`); // Log the masked account address
 
 // Example usage of different log levels:
 // logger.debug('This is a debug message.');


### PR DESCRIPTION
Potential fix for [https://github.com/ewdlop/BlockChainDevelopmentNote/security/code-scanning/3](https://github.com/ewdlop/BlockChainDevelopmentNote/security/code-scanning/3)

To fix the problem, we should avoid logging the account address directly. Instead, we can log a masked version of the account address to ensure that sensitive information is not exposed. Masking can be done by showing only a part of the address, such as the first and last few characters, while replacing the middle part with asterisks or another placeholder.

We will modify the code on line 27 to log a masked version of the account address. We will also add a helper function to mask the account address.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
